### PR TITLE
Feature/replace lodash with lodash es

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -25,8 +25,7 @@
             "aot": false,
             "assets": ["src/favicon.ico", "src/assets"],
             "styles": ["src/styles.scss"],
-            "scripts": [],
-            "allowedCommonJsDependencies": ["uuid"]
+            "scripts": []
           },
           "configurations": {
             "production": {

--- a/angular.json
+++ b/angular.json
@@ -26,7 +26,7 @@
             "assets": ["src/favicon.ico", "src/assets"],
             "styles": ["src/styles.scss"],
             "scripts": [],
-            "allowedCommonJsDependencies": ["lodash", "uuid"]
+            "allowedCommonJsDependencies": ["uuid"]
           },
           "configurations": {
             "production": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2123,6 +2123,15 @@
       "integrity": "sha512-InCEXJNTv/59yO4VSfuvNrZHt7eeNtWQEgnieIA+mIC+MOWM9arOWG2eQ8Vhk6NbOre6/BidiXhkZYeDY9U35w==",
       "dev": true
     },
+    "@types/lodash-es": {
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.3.tgz",
+      "integrity": "sha512-iHI0i7ZAL1qepz1Y7f3EKg/zUMDwDfTzitx+AlHhJJvXwenP682ZyGbgPSc5Ej3eEAKVbNWKFuwOadCj5vBbYQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/mime": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
@@ -8953,6 +8962,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
+    },
+    "lodash-es": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
+      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2226,9 +2226,9 @@
       "optional": true
     },
     "@types/uuid": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz",
-      "integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.0.1.tgz",
+      "integrity": "sha512-2kE8rEFgJpbBAPw5JghccEevQb0XVU0tewF/8h7wPQTeCtoJ6h8qmBIwuzUVm2MutmzC/cpCkwxudixoNYDp1A==",
       "dev": true
     },
     "@types/webpack-sources": {
@@ -12360,6 +12360,12 @@
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
           "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
           "dev": true
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -13424,6 +13430,14 @@
         "faye-websocket": "^0.10.0",
         "uuid": "^3.4.0",
         "websocket-driver": "0.6.5"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "sockjs-client": {
@@ -14671,6 +14685,12 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -14926,9 +14946,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -15880,6 +15900,14 @@
       "requires": {
         "ansi-colors": "^3.0.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "webpack-merge": {

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
     "@ngrx/store-devtools": "^8.6.0",
     "@nguniversal/express-engine": "^10.0.1",
     "express": "^4.15.2",
+    "lodash-es": "^4.14.149",
     "rxjs": "^6.5.5",
     "tslib": "^2.0.0",
-    "uuid": "^3.4.0",
+    "uuid": "^8.3.0",
     "web-animations-js": "^2.3.2",
-    "zone.js": "^0.10.3",
-    "lodash-es": "^4.14.149"
+    "zone.js": "^0.10.3"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^0.1000.4",
@@ -53,7 +53,7 @@
     "@types/jasminewd2": "^2.0.8",
     "@types/lodash-es": "^4.14.149",
     "@types/node": "^13.11.1",
-    "@types/uuid": "^3.4.8",
+    "@types/uuid": "^8.0.1",
     "codelyzer": "^6.0.0",
     "jasmine-core": "~3.5.0",
     "jasmine-spec-reporter": "~5.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "tslib": "^2.0.0",
     "uuid": "^3.4.0",
     "web-animations-js": "^2.3.2",
-    "zone.js": "^0.10.3"
+    "zone.js": "^0.10.3",
+    "lodash-es": "^4.14.149"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^0.1000.4",
@@ -50,7 +51,7 @@
     "@types/express": "^4.17.6",
     "@types/jasmine": "^3.5.10",
     "@types/jasminewd2": "^2.0.8",
-    "@types/lodash": "^4.14.149",
+    "@types/lodash-es": "^4.14.149",
     "@types/node": "^13.11.1",
     "@types/uuid": "^3.4.8",
     "codelyzer": "^6.0.0",

--- a/projects/ngrx-store-storagesync/package.json
+++ b/projects/ngrx-store-storagesync/package.json
@@ -29,7 +29,7 @@
     "@ngrx/store": ">=8.0.0",
     "@angular/common": ">=7.0.0",
     "@angular/core": ">=7.0.0",
-    "lodash": ">=4.0.0"
+    "lodash-es": ">=4.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/projects/ngrx-store-storagesync/src/lib/form-sync/store/form.reducer.ts
+++ b/projects/ngrx-store-storagesync/src/lib/form-sync/store/form.reducer.ts
@@ -1,5 +1,9 @@
 import { createReducer, on } from '@ngrx/store';
-import { cloneDeep, isArray, isPlainObject, merge } from 'lodash-es';
+import cloneDeep from 'lodash-es/cloneDeep';
+import isArray from 'lodash-es/isArray';
+import isPlainObject from 'lodash-es/isPlainObject';
+import merge from 'lodash-es/merge';
+
 import { deleteForm, patchForm, resetForm, setForm } from './form.actions';
 
 export interface IFormSyncState {

--- a/projects/ngrx-store-storagesync/src/lib/form-sync/store/form.reducer.ts
+++ b/projects/ngrx-store-storagesync/src/lib/form-sync/store/form.reducer.ts
@@ -1,5 +1,5 @@
 import { createReducer, on } from '@ngrx/store';
-import { cloneDeep, isArray, isPlainObject, merge } from 'lodash';
+import { cloneDeep, isArray, isPlainObject, merge } from 'lodash-es';
 import { deleteForm, patchForm, resetForm, setForm } from './form.actions';
 
 export interface IFormSyncState {

--- a/projects/ngrx-store-storagesync/src/lib/storage-sync/state-sync.ts
+++ b/projects/ngrx-store-storagesync/src/lib/storage-sync/state-sync.ts
@@ -1,4 +1,5 @@
-import { cloneDeep, isPlainObject } from 'lodash-es';
+import cloneDeep from 'lodash-es/cloneDeep';
+import isPlainObject from 'lodash-es/isPlainObject';
 import { IStorageSyncOptions } from './models/storage-sync-options';
 
 

--- a/projects/ngrx-store-storagesync/src/lib/storage-sync/state-sync.ts
+++ b/projects/ngrx-store-storagesync/src/lib/storage-sync/state-sync.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, isPlainObject } from 'lodash';
+import { cloneDeep, isPlainObject } from 'lodash-es';
 import { IStorageSyncOptions } from './models/storage-sync-options';
 
 

--- a/projects/ngrx-store-storagesync/src/lib/storage-sync/storage-sync.ts
+++ b/projects/ngrx-store-storagesync/src/lib/storage-sync/storage-sync.ts
@@ -1,5 +1,5 @@
 import { Action } from '@ngrx/store';
-import { merge } from 'lodash';
+import { merge } from 'lodash-es';
 import { INIT_ACTION, INIT_ACTION_EFFECTS, UPDATE_ACTION } from './actions';
 import { IStorageSyncOptions } from './models/storage-sync-options';
 import { rehydrateState } from './rehydrate-state';

--- a/projects/ngrx-store-storagesync/src/lib/storage-sync/storage-sync.ts
+++ b/projects/ngrx-store-storagesync/src/lib/storage-sync/storage-sync.ts
@@ -1,5 +1,5 @@
 import { Action } from '@ngrx/store';
-import { merge } from 'lodash-es';
+import merge from 'lodash-es/merge';
 import { INIT_ACTION, INIT_ACTION_EFFECTS, UPDATE_ACTION } from './actions';
 import { IStorageSyncOptions } from './models/storage-sync-options';
 import { rehydrateState } from './rehydrate-state';

--- a/src/app/modules/todo/store/todo.reducer.ts
+++ b/src/app/modules/todo/store/todo.reducer.ts
@@ -1,5 +1,5 @@
 import { createReducer, on } from '@ngrx/store';
-import uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 
 import { ITodo } from '../models/todo';
 import * as todoActions from './todo.actions';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,7 +7,6 @@
     "declaration": false,
     "downlevelIteration": true,
     "experimentalDecorators": true,
-    "allowSyntheticDefaultImports": true,
     "module": "es2020",
     "moduleResolution": "node",
     "importHelpers": true,


### PR DESCRIPTION
@larscom First thing first :) thank you very much for this nice project! 

We use your package in our project, however it is causing some tree shaking issues that I aim to solve with this PR :)

## The issue ##
When this package is included within another Angular 10 project, it will result in the following error:
```
WARNING in <path_to_project>\node_modules\@larscom\ngrx-store-storagesync\__ivy_ngcc__\fesm2015\larscom-ngrx-store-storagesync.js depends on 'lodash'. CommonJS or AMD dependencies can cause optimization bailouts.
For more info see: https://angular.io/guide/build#configuring-commonjs-dependencies
```

After some searching, this occurs because the non es6 module variant of lodash is used (and this is not tree shakable).

## The solution ##
With some guidance from [this](https://medium.com/@martin_hotell/tree-shake-lodash-with-webpack-jest-and-typescript-2734fa13b5cd) article I switched lodash out for its es6 variant (lodash-es) and removed some no longer needed configuration settings from the example project (making it closer to stock Angular 10 )

This also required the update of the uuid package (since only from version 8.0.0 they converted to es6)

## Testing ##
- I ran the tests and they are all passing
- I also built the lib which builded
- I als server the example application which served without errors.

I'm happy to contribute and I hope you can take a look at my PR and if deemed acceptable It can be merged into the main repo (and released on npm of-course) :D 
